### PR TITLE
update and match the master

### DIFF
--- a/config/promitor/resource-discovery/resource-discovery-declaration.yaml
+++ b/config/promitor/resource-discovery/resource-discovery-declaration.yaml
@@ -1,6 +1,6 @@
 version: v1
 azureLandscape:
-  tenantId: 56c6cf98-bd87-4684-ad83-f3b41dfdcb21
+  tenantId: 84b51e0a-2749-4060-bb46-111141978ee6
   subscriptions:
   - 3566a5fa-878c-40fd-ac37-ef0ba0eee29d
   cloud: Global

--- a/config/promitor/resource-discovery/runtime.yaml
+++ b/config/promitor/resource-discovery/runtime.yaml
@@ -2,7 +2,7 @@ server:
   httpPort: 88
 authentication:
   mode: ServicePrincipal
-  identityId: 90a927a2-fa24-414a-a961-70f574d14df9
+  identityId: 7e2355f7-3f11-47fd-9b16-c8f8ec527a48
 telemetry:
   applicationInsights:
     instrumentationKey: ABC

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -1,6 +1,6 @@
 version: v1
 azureMetadata:
-  tenantId: 56c6cf98-bd87-4684-ad83-f3b41dfdcb21
+  tenantId: 84b51e0a-2749-4060-bb46-111141978ee6
   subscriptionId: 3566a5fa-878c-40fd-ac37-ef0ba0eee29d
   resourceGroupName: promitor-testing-infrastructure-europe
 metricDefaults:
@@ -365,7 +365,7 @@ metrics:
       aggregation:
         interval: 7:00:00:00
     resources:
-      - workspaceId: 7f07e0fe-36e7-44c8-b79c-7c7f65cb81a2
+      - workspaceId: 2c4a3924-d005-4d30-bc8e-d794050375c0
         workspaceName: promitor-testing-resource-eu-logs
   - name: azure_container_instance_cpu_usage_discovered
     description: "Average cpu usage of our container instance"

--- a/config/promitor/scraper/runtime.yaml
+++ b/config/promitor/scraper/runtime.yaml
@@ -2,7 +2,7 @@ server:
   httpPort: 88
 authentication:
   mode: ServicePrincipal
-  identityId: bd16d14f-7161-432b-86ad-0c31dfef44ac
+  identityId: a2282f2d-c090-4123-85c3-44b122b8db8d
 metricSinks:
   atlassianStatuspage:
     pageId: 4mwc0ny6bgw1


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
